### PR TITLE
Add License to Gemspec

### DIFF
--- a/chartjs-ror.gemspec
+++ b/chartjs-ror.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = 'Simplifies using Chart.js in Rails'
   gem.summary       = 'Simplifies using Chart.js in Rails'
   gem.homepage      = 'https://github.com/airblade/chartjs-ror'
+  gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Why:
* The License used by this gem were missing from the Gemspec. This
  prevents automatic means of getting the licenses used by all the gems
  used in a project.

This change addresses the issue by:
* Adding `MIT` to the license attribute in the
  Gemspec.